### PR TITLE
add Applicative DocM instance, bump version

### DIFF
--- a/CoreErlang.cabal
+++ b/CoreErlang.cabal
@@ -1,5 +1,5 @@
 name: CoreErlang
-version: 0.0.2
+version: 0.0.3
 copyright: 2008, David Castro Pérez, Henrique Ferreiro García
 license: BSD3
 license-file: LICENSE

--- a/Language/CoreErlang/Pretty.hs
+++ b/Language/CoreErlang/Pretty.hs
@@ -75,6 +75,10 @@ newtype DocM s a = DocM (s -> a)
 instance Functor (DocM s) where
          fmap f xs = do x <- xs; return (f x)
 
+instance Applicative (DocM s) where
+         pure        = return
+         (<*>) m1 m2 = do x1 <- m1; x2 <- m2; return (x1 x2)
+
 instance Monad (DocM s) where
          (>>=) = thenDocM
          (>>) = then_DocM


### PR DESCRIPTION
GHC 7.10/base 4.8 makes Monad a subclass of Applicative, which breaks CoreErlang.Pretty since there is no `instance Applicate (DocM s)`. I added an Applicative instance in accordance with the [migration guide](https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10). It compiles and works (unsurprisingly, since the Applicative instance isn't used!) on some Core Erlang files I had at hand to try with.
