### PR TITLE
Include latest base version in the depedency version range

### DIFF
--- a/CoreErlang.cabal
+++ b/CoreErlang.cabal
@@ -25,7 +25,7 @@ library
         Language.CoreErlang.Pretty,
         Language.CoreErlang.Syntax
   build-depends:       
-        base >=4.8 && <4.9, 
+        base >=4.8 && <4.10, 
         pretty >=1.1 && <1.2, 
         parsec >=3.1 && <3.2
   other-extensions:    DeriveDataTypeable


### PR DESCRIPTION
This change is required (right?) in order to use the library with the latest base-version.
