### PR TITLE
Update base version

### DIFF
--- a/CoreErlang.cabal
+++ b/CoreErlang.cabal
@@ -1,5 +1,5 @@
 name: CoreErlang
-version: 0.0.4
+version: 0.0.5
 copyright: 2008, David Castro Pérez, Henrique Ferreiro García
 license: BSD3
 license-file: LICENSE
@@ -25,7 +25,7 @@ library
         Language.CoreErlang.Pretty,
         Language.CoreErlang.Syntax
   build-depends:       
-        base >=4.8 && <=4.11,
+        base >=4.8 && < 5,
         pretty >=1.1 && <1.2, 
         parsec >=3.1 && <3.2
   other-extensions:    DeriveDataTypeable

--- a/CoreErlang.cabal
+++ b/CoreErlang.cabal
@@ -25,7 +25,7 @@ library
         Language.CoreErlang.Pretty,
         Language.CoreErlang.Syntax
   build-depends:       
-        base >=4.8 && < 5,
+        base >=4.8 && <4.15,
         pretty >=1.1 && <1.2, 
         parsec >=3.1 && <3.2
   other-extensions:    DeriveDataTypeable

--- a/Language/CoreErlang/Pretty.hs
+++ b/Language/CoreErlang/Pretty.hs
@@ -26,6 +26,8 @@ import Language.CoreErlang.Syntax
 
 import qualified Text.PrettyPrint as P
 
+import Prelude hiding ((<>))
+
 infixl 5 $$$
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Update base version to 4.14 (supporting GHC 8.10.2), and fix an associated error

Base <= 4.11 doesn't let me use haskell-language-server, which I would like to use in my project